### PR TITLE
Add support for additional environment variables in CodeBuild

### DIFF
--- a/aws_codebuild_project.tf
+++ b/aws_codebuild_project.tf
@@ -20,6 +20,14 @@ resource "aws_codebuild_project" "builder" {
       value = aws_security_group.codebuild.id
     }
 
+    dynamic "environment_variable" {
+      for_each = var.additional_environment_variables
+      content {
+        name  = environment_variable.value.name
+        value = environment_variable.value.value
+        type  = environment_variable.value.type
+      }
+    }
   }
 
   source {

--- a/variables.tf
+++ b/variables.tf
@@ -65,6 +65,16 @@ variable "common_tags" {
   type = map(string)
 }
 
+variable "additional_environment_variables" {
+  description = "Additional environment variables to pass to CodeBuild. These are merged with the default AWS_CODEBUILD_SG_ID variable."
+  type = list(object({
+    name  = string
+    value = string
+    type  = optional(string, "PLAINTEXT")
+  }))
+  default = []
+}
+
 locals {
   ami_install_commands = [
   ]


### PR DESCRIPTION
`-` Enhanced CodeBuild configuration to include support for additional environment variables. This change allows greater customization and flexibility in build setups.